### PR TITLE
Split CSS files and force light theme for tweet preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10033,9 +10033,9 @@
       }
     },
     "react-tweet-card": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/react-tweet-card/-/react-tweet-card-0.1.9.tgz",
-      "integrity": "sha512-k0lEKHq5FRy9utJ827v2Sss/XRouRCRir3xT2Z7I+6mveeh/Uzf+w1ViFPgQj3RYWCxQWttlkvIKhMgzBs1ovA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/react-tweet-card/-/react-tweet-card-0.2.0.tgz",
+      "integrity": "sha512-zk3Q9jO2Dspm3rXbbzFK8X3I8t6WyyBtad4PdGTMhdo6Hurf1W4sRPRJJ1Aq0Yn8M4ftgblIoPljDFjTDqD+Aw=="
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
     "react-scripts": "5.0.1",
-    "react-tweet-card": "^0.1.9",
+    "react-tweet-card": "^0.2.0",
     "tabler-icons-react": "^1.50.0",
     "typescript": "^4.7.4",
     "unique-names-generator": "^4.7.1",

--- a/src/App.css
+++ b/src/App.css
@@ -10,14 +10,6 @@
   padding: 2%;
 }
 
-.field {
-  margin: 9px 0;
-}
-
-.checkbox-field {
-  margin: 18px 0 14px 0;
-}
-
 .outer {
   display: table;
   position: absolute;
@@ -36,20 +28,4 @@
   margin-left: auto;
   margin-right: auto;
   width: 400px;
-}
-
-.anchor {
-  margin-right: 9px;
-}
-
-.anchor:last-child {
-  margin-right: 0;
-}
-
-.mantine-Accordion-itemTitle > button:first-child {
-  padding: 14px 8px;
-}
-
-.mantine-Accordion-label {
-  font-size: 14px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,9 @@ import {
 import { useAppDispatch, useAppSelector } from "./redux/hooks";
 import TweetConfiguration from "./components/TweetConfiguration/TweetConfiguration";
 import TweetPreview from "./components/TweetPreview/TweetPreview";
+import { Options } from "html-to-image/lib/options";
 
-function App() {
+const App = () => {
   const tweetConfiguration: ITweetConfiguration = useAppSelector((state) => state.tweetConfiguration);
   const dispatch = useAppDispatch();
   const ref = useRef(null);
@@ -25,6 +26,17 @@ function App() {
     return () => clearInterval(interval);
   }, [dispatch]);
 
+  const toPngOptions: Options = {
+    cacheBust: true,
+    width: 1080,
+    height: 1080,
+    skipAutoScale: false,
+    canvasWidth: 1080,
+    canvasHeight: 1080,
+    backgroundColor: tweetConfiguration.tweetBackgroundColor,
+    pixelRatio: 4,
+  };
+
   const onButtonClick = useCallback(() => {
     if (ref.current === null) {
       return;
@@ -32,16 +44,7 @@ function App() {
 
     dispatch(updateIsImageDownloading(true));
 
-    toPng(ref.current, {
-      cacheBust: true,
-      width: 1080,
-      height: 1080,
-      skipAutoScale: false,
-      canvasWidth: 1080,
-      canvasHeight: 1080,
-      backgroundColor: tweetConfiguration.tweetBackgroundColor,
-      pixelRatio: 4,
-    }).then((dataUrl) => {
+    toPng(ref.current, toPngOptions).then((dataUrl) => {
         const link = document.createElement("a");
         link.download = getRandomFilename();
         link.href = dataUrl;
@@ -54,8 +57,8 @@ function App() {
       });
   }, [ref, tweetConfiguration, dispatch]);
 
-  return (
-    <>
+  const HiddenTweetPreview = () => {
+    return (
       <div style={{display: "none"}}>
         <div className="outer" ref={ref}>
           <div className="middle">
@@ -67,11 +70,21 @@ function App() {
           </div>
         </div>
       </div>
+    );
+  };
+
+  const Header = () => {
+    return (
       <Grid justify="center" grow gutter="xs" style={{marginRight: "0"}}>
         <Grid.Col className="header-container">
           <AppHeader />
         </Grid.Col>
       </Grid>
+    );
+  };
+
+  const TweetConfigurationAndPreview = () => {
+    return (
       <Grid justify="center" grow gutter="xs" style={{marginRight: "0"}}>
         <Grid.Col className="form-container" xs={12} sm={12} md={6} lg={6} xl={6}>
           <TweetConfiguration handleButtonClick={onButtonClick} />
@@ -83,8 +96,16 @@ function App() {
           </div>
         </Grid.Col>
       </Grid>
+    );
+  };
+
+  return (
+    <>
+      <HiddenTweetPreview />
+      <Header />
+      <TweetConfigurationAndPreview />
     </>
   );
-}
+};
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import "./App.css";
 import { toPng } from "html-to-image";
 import { Grid } from "@mantine/core";
@@ -26,16 +26,18 @@ const App = () => {
     return () => clearInterval(interval);
   }, [dispatch]);
 
-  const toPngOptions: Options = {
-    cacheBust: true,
-    width: 1080,
-    height: 1080,
-    skipAutoScale: false,
-    canvasWidth: 1080,
-    canvasHeight: 1080,
-    backgroundColor: tweetConfiguration.tweetBackgroundColor,
-    pixelRatio: 4,
-  };
+  const toPngOptions: Options = useMemo(() => {
+    return {
+      cacheBust: true,
+      width: 1080,
+      height: 1080,
+      skipAutoScale: false,
+      canvasWidth: 1080,
+      canvasHeight: 1080,
+      backgroundColor: tweetConfiguration.tweetBackgroundColor,
+      pixelRatio: 4,
+    };
+  }, [tweetConfiguration]);
 
   const onButtonClick = useCallback(() => {
     if (ref.current === null) {
@@ -55,10 +57,10 @@ const App = () => {
         console.log(err);
         dispatch(updateIsImageDownloading(false));
       });
-  }, [ref, tweetConfiguration, dispatch]);
+  }, [ref, dispatch, toPngOptions]);
 
-  const HiddenTweetPreview = () => {
-    return (
+  return (
+    <>
       <div style={{display: "none"}}>
         <div className="outer" ref={ref}>
           <div className="middle">
@@ -70,21 +72,11 @@ const App = () => {
           </div>
         </div>
       </div>
-    );
-  };
-
-  const Header = () => {
-    return (
       <Grid justify="center" grow gutter="xs" style={{marginRight: "0"}}>
         <Grid.Col className="header-container">
           <AppHeader />
         </Grid.Col>
       </Grid>
-    );
-  };
-
-  const TweetConfigurationAndPreview = () => {
-    return (
       <Grid justify="center" grow gutter="xs" style={{marginRight: "0"}}>
         <Grid.Col className="form-container" xs={12} sm={12} md={6} lg={6} xl={6}>
           <TweetConfiguration handleButtonClick={onButtonClick} />
@@ -96,14 +88,6 @@ const App = () => {
           </div>
         </Grid.Col>
       </Grid>
-    );
-  };
-
-  return (
-    <>
-      <HiddenTweetPreview />
-      <Header />
-      <TweetConfigurationAndPreview />
     </>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ function App() {
           <div className="middle">
             <div className="inner">
               <div id="exportContainer">
-                <TweetPreview className="tweet-card"customStyle={{fontSize: "14px"}} />
+                <TweetPreview className="tweet-card" customStyle={{fontSize: "14px"}} />
               </div>
             </div>
           </div>

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -1,0 +1,7 @@
+.anchor {
+    margin-right: 9px;
+}
+  
+.anchor:last-child {
+    margin-right: 0;
+}

--- a/src/components/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppHeader/AppHeader.test.tsx
@@ -1,8 +1,0 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import AppHeader from "./AppHeader";
-
-test("should render correctly", () => {
-    render(<AppHeader />);
-    expect(screen.getByText("Tweet to Image")).toBeInTheDocument();
-});

--- a/src/components/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppHeader/AppHeader.test.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AppHeader from "./AppHeader";
+
+test("should render correctly", () => {
+    render(<AppHeader />);
+    expect(screen.getByText("Tweet to Image")).toBeInTheDocument();
+});

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -1,4 +1,5 @@
 import { Anchor, Center, Title, Text } from "@mantine/core";
+import "./AppHeader.css";
 
 const AppHeader = () => {
     return (

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -4,7 +4,7 @@ import "./AppHeader.css";
 const AppHeader = () => {
     return (
         <>
-            <Title order={1} align="center">Tweet to image</Title>
+            <Title order={1} align="center">Tweet to Image</Title>
             <Text align="center">Download a Tweet as an Instagram-ready image</Text>
             <Center>
             <Anchor href="https://github.com/ClydeDz/tweet-to-image/issues/new/choose"

--- a/src/components/TweetConfiguration/TweetConfiguration.css
+++ b/src/components/TweetConfiguration/TweetConfiguration.css
@@ -1,0 +1,15 @@
+.field {
+    margin: 9px 0;
+}
+
+.checkbox-field {
+    margin: 18px 0 14px 0;
+}
+
+.mantine-Accordion-itemTitle > button:first-child {
+    padding: 14px 8px;
+}
+  
+.mantine-Accordion-label {
+    font-size: 14px;
+}

--- a/src/components/TweetConfiguration/TweetConfiguration.tsx
+++ b/src/components/TweetConfiguration/TweetConfiguration.tsx
@@ -1,4 +1,4 @@
-import "../../App.css";
+import "./TweetConfiguration.css";
 import {
   Accordion,
   Button,

--- a/src/components/TweetPreview/TweetPreview.tsx
+++ b/src/components/TweetPreview/TweetPreview.tsx
@@ -22,8 +22,7 @@ const TweetPreview = (props: ITweetPreviewProps) => {
             tweet={tweetConfiguration.tweetContent}
             time={tweetConfiguration.tweetTimestamp}
             source={tweetConfiguration.tweetSource}
-            fitInsideContainer={false}
-            clickableProfileLink={false}
+            theme="light"
             showEngagement={toBoolean(tweetConfiguration.showTweetEngagement)}
             engagement={tweetConfiguration.tweetEngagement}
             style={customStyle}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";


### PR DESCRIPTION
## What has changed and why?
- Split CSS files
- Force light theme for tweet preview

## Does this fix an open issue? 
No

## Type of change   
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist  
- [x] I have followed the [`CONTRIBUTING` document](https://github.com/ClydeDz/tweet-to-image/blob/main/CONTRIBUTING.md) and have updated the required files.
- [x] My code follows the code style of this project.
- [ ] All new and existing tests passed.
- [x] I've manually tested this change locally to ensure no errors appear.
